### PR TITLE
bug fixing

### DIFF
--- a/ColdStaking.sol
+++ b/ColdStaking.sol
@@ -1,101 +1,151 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.12;
 
 import './safeMath.sol';
 
-contract cold_staking {
+contract ColdStaking {
     
-        using SafeMath for uint256;
-        
-        struct Staker
+    // NOTE: The contract only works for intervals of time > round_interval
+
+    using SafeMath for uint256;
+
+    event StartStaking(address addr, uint256 value, uint256 weight, uint256 init_block);
+    event WithdrawStake(address staker, uint256 weight);
+    event Claim(address staker, uint256 reward);
+    event DonationDeposited(address _address, uint256 value);
+
+
+    struct Staker
+    {
+        uint256 weight;
+        uint256 init_block;
+    }
+
+    uint256 public staking_pool;
+
+    uint256 public staking_threshold = 0 ether;
+
+    //uint256 public round_interval    = 172800; // approx. 1 month in blocks
+    //uint256 public max_delay      = 172800 * 12; // approx. 1 year in blocks
+
+
+    /// TESTING VALUES
+    uint256 public round_interval = 15; // approx. 1 month in blocks
+    uint256 public max_delay = 7 * 6000; // approx. 1 year in blocks
+
+    mapping(address => Staker) staker;
+
+
+    function() public payable
+    {
+        // No donations accepted to fallback!
+        // Consider value deposit is an attempt to become staker.
+        start_staking();
+    }
+
+    function start_staking() public payable
+    {
+        assert(msg.value >= staking_threshold);
+        staking_pool = staking_pool.add(msg.value);
+        staker[msg.sender].weight = staker[msg.sender].weight.add(msg.value);
+        staker[msg.sender].init_block = block.number;
+
+        emit StartStaking(
+            msg.sender,
+            msg.value,
+            staker[msg.sender].weight,
+            staker[msg.sender].init_block
+        );
+
+
+    }
+
+
+    function DEBUG_donation() public payable {
+
+        emit DonationDeposited(msg.sender, msg.value);
+
+    }
+
+    function claim_and_withdraw() public
+    {
+        claim();
+        withdraw_stake();
+    }
+
+    function withdraw_stake() public only_staker
+    {
+        uint _weight = staker[msg.sender].weight;
+        staking_pool = staking_pool.sub(_weight);
+        staker[msg.sender].weight = 0;
+        msg.sender.transfer(_weight);
+        emit WithdrawStake(msg.sender, _weight);
+    }
+
+    function claim() public only_staker
+    {
+        require(block.number >= staker[msg.sender].init_block.add(round_interval));
+
+        uint256 _reward = stake_reward(msg.sender);
+        staker[msg.sender].init_block = block.number;
+        msg.sender.transfer(_reward);
+
+        emit Claim(msg.sender, _reward);
+    }
+
+    function stake_reward(address _addr) public constant returns (uint256 _reward)
+    {
+        return (staker_time_stake(_addr) * staker_weight_stake(_addr));
+    }
+    function staker_time_stake(address _addr) public constant returns (uint256 _time)
+    {
+        return ((block.number - staker[_addr].init_block) / round_interval);
+    }
+    function staker_weight_stake(address _addr) public constant returns (uint256 _stake)
+    {
+        return ( (reward() * staker[_addr].weight) / (staking_pool + staker[_addr].weight * (staker_time_stake(_addr) - 1)) );
+    }
+
+    function report_abuse(address _addr) public only_staker
+    {
+        require(staker[_addr].weight > 0);
+        require(block.number > staker[_addr].init_block.add(max_delay));
+        uint _weight = staker[_addr].weight;
+        staker[_addr].weight = 0;
+        _addr.transfer(_weight);
+    }
+
+    function reward() public constant returns (uint256)
+    {
+        return address(this).balance.sub(staking_pool);
+    }
+
+    modifier only_staker
+    {
+        require(staker[msg.sender].weight > 0);
+        _;
+    }
+
+
+    ////////////// DEBUGGING /////////////////////////////////////////////////////////////
+
+    function staker_info(address _addr) public constant returns
+    (uint256 weight, uint256 init, uint256 _stake_time, uint256 _reward)
+    {
+        _stake_time = 0;
+        _reward = 0;
+        if (staker[_addr].init_block > 0)
         {
-            uint256 weight;
-            uint256 init_block;
-            uint256 last_claim_block;
+            _stake_time = block.number - staker[_addr].init_block;
         }
-        
-        uint256 public staking_pool;
-        
-        uint256 public staking_threshold = 1000 ether;
-        //uint256 public claim_delay    = 175000; // 1 month in blocks
-        
-        uint256 public claim_delay    = 0;
-        uint256 public max_delay      = 1750000;
-        
-        mapping (address => Staker) staker;
-        
-        function() payable
+        if (block.number - staker[_addr].init_block > round_interval)
         {
-            // No donations accepted! Consider any value deposit
-            // is an attempt to become staker.
-            become_staker();
+            _reward = stake_reward(_addr);
         }
-        
-        function become_staker() payable
-        {
-            assert(msg.value >= staking_threshold);
-            staking_pool.add(msg.value);
-            staker[msg.sender].weight.add(msg.value);
-            staker[msg.sender].init_block = block.number;
-            staker[msg.sender].last_claim_block = block.number;
-        }
-        
-        function withdraw_stake() only_staker mutex(msg.sender)
-        {
-            msg.sender.transfer(staker[msg.sender].weight);
-            staking_pool.sub(staker[msg.sender].weight);
-            staker[msg.sender].weight.sub(staker[msg.sender].weight);
-        }
-        
-        function claim() only_staker
-        {
-            require(block.number >= staker[msg.sender].last_claim_block.add(claim_delay));
-            msg.sender.transfer(reward(msg.sender));
-            staker[msg.sender].last_claim_block = block.number;
-        }
-        
-        function reward(address _addr) constant returns (uint256 _reward)
-        {
-            return (staker[_addr].weight / staking_pool * reward_pool());
-        }
-        
-        function report_abuse(address _addr) only_staker
-        {
-            assert(staker[_addr].weight > 0);
-            assert(block.number > staker[_addr].last_claim_block.add(max_delay));
-            
-            _addr.transfer(staker[msg.sender].weight);
-            staker[_addr].weight = 0;
-        }
-        
-        
-        /*
-        function delay_round(address _addr) private constant returns (uint256 _rounds)
-        {
-            
-        }*/
-        
-        function reward_pool() constant returns (uint256)
-        {
-            return this.balance.sub(staking_pool);
-        }
-        
-        modifier only_staker
-        {
-            assert(staker[msg.sender].weight > 0);
-            _;
-        }
-        
-    
-        mapping (address => bool) private muted;
-        modifier mutex(address _target)
-        {
-            if( muted[_target] )
-            {
-                revert();
-            }
-        
-            muted[_target] = true;
-            _;
-            muted[_target] = false;
-        }
+        return (
+        staker[_addr].weight,
+        staker[_addr].init_block,
+        _stake_time,
+        _reward
+        );
+    }
 }

--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ Reference implementation of smart-contract based cold staking protocol. Formal d
 https://docs.google.com/document/d/1LpRHzW7gGV1JfiXUQOmW-UEVF9TCNNWrYiItDuLgiGA/edit?usp=sharing
 
 The protocol is currently in proof of concept phase.
-
-Rinkeby address 0xa3a278371d1569d849f93f4241c7812969e863a3 .


### PR DESCRIPTION

### Fixed [function report_abuse(address _addr)](https://github.com/EthereumCommonwealth/Cold-staking/blob/82e0c3eade3b65f67656381f7778dead01647701/ColdStaking.sol#L110).

I think it must transfer all ```staker[_addr].weight``` to staker with more then max_delay staking time. But it [transfer calling staker weight](https://github.com/EthereumCommonwealth/Cold-staking/blob/82e0c3eade3b65f67656381f7778dead01647701/ColdStaking.sol#L115)

It may looks like:

```
    function report_abuse(address _addr) public only_staker
    {
        assert(staker[_addr].weight > 0);
        assert(block.number > staker[_addr].init_block.add(max_delay));
        uint _weight = staker[_addr].weight;
        staker[_addr].weight = 0;
        _addr.transfer(_weight);
    }
```

also no need modifier mutex().

### Fixed [function withdraw_stake()](https://github.com/EthereumCommonwealth/Cold-staking/blob/82e0c3eade3b65f67656381f7778dead01647701/ColdStaking.sol#L76-L84) and [function claim()](https://github.com/EthereumCommonwealth/Cold-staking/blob/82e0c3eade3b65f67656381f7778dead01647701/ColdStaking.sol#L86)

### Removed unused Modifier [mutex()](https://github.com/EthereumCommonwealth/Cold-staking/blob/82e0c3eade3b65f67656381f7778dead01647701/ColdStaking.sol#L130)
